### PR TITLE
Tick mark across y-axis for all series

### DIFF
--- a/asciichartpy/__init__.py
+++ b/asciichartpy/__init__.py
@@ -172,12 +172,11 @@ def plot(series, cfg=None):
         result[y - min2][max(offset - len(label), 0)] = label
         result[y - min2][offset - 1] = symbols[0] if y == 0 else symbols[1]  # zero tick mark
 
-    # first value is a tick mark across the y-axis
-    d0 = series[0][0]
-    if _isnum(d0):
-        result[rows - scaled(d0)][offset - 1] = symbols[0]
-
     for i in range(0, len(series)):
+        # first value is a tick mark across the y-axis
+        d0 = series[i][0]
+        if _isnum(d0):
+            result[rows - scaled(d0)][offset - 1] = symbols[0]
 
         color = colors[i % len(colors)]
 


### PR DESCRIPTION
I noticed the Python version only puts a tick across the y-axis for the first series and not subsequent ones. The Javascript version appears to do it correctly. This simple PR moves the first value tick code into the series loop.